### PR TITLE
Missing data type in socket transfer

### DIFF
--- a/Builder_Lib/src/main/java/ca/wise/fgm/output/SocketDecoder.java
+++ b/Builder_Lib/src/main/java/ca/wise/fgm/output/SocketDecoder.java
@@ -179,7 +179,8 @@ public class SocketDecoder {
 		FGM_SETTINGS("fgm_settings"),
 		UNIT_SETTINGS("export_units"),
 		SCENARIO_SEASONAL("scenario_seasonal"),
-		STOP_MODELLING("stop_modelling");
+		STOP_MODELLING("stop_modelling"),
+		GUSTING_OPTIONS("gusting_options");
 		
 		private String val;
 		private static List<String> valList = null;


### PR DESCRIPTION
Missed defining the ID for transferring wind gusting information over the socket from the JS API.